### PR TITLE
Expose events optionally over TCP

### DIFF
--- a/software/earl/event-list.go
+++ b/software/earl/event-list.go
@@ -1,0 +1,9 @@
+package main
+
+type EventList []*JsonAppEvent
+
+func (el EventList) Len() int { return len(el) }
+func (el EventList) Less(i, j int) bool {
+	return el[i].Timestamp.Before(el[j].Timestamp)
+}
+func (el EventList) Swap(i, j int) { el[i], el[j] = el[j], el[i] }

--- a/software/earl/http-api.go
+++ b/software/earl/http-api.go
@@ -84,14 +84,6 @@ func (a *ApiServer) collectLastEvents() {
 	}
 }
 
-type EventList []*JsonAppEvent
-
-func (el EventList) Len() int { return len(el) }
-func (el EventList) Less(i, j int) bool {
-	return el[i].Timestamp.Before(el[j].Timestamp)
-}
-func (el EventList) Swap(i, j int) { el[i], el[j] = el[j], el[i] }
-
 func (a *ApiServer) getHistory() []*JsonAppEvent {
 	result := EventList{}
 	a.lastEventsLock.Lock()

--- a/software/earl/main.go
+++ b/software/earl/main.go
@@ -112,7 +112,8 @@ func main() {
 	userFileName := flag.String("users", "/var/access/users.csv", "User Authentication file.")
 	logFileName := flag.String("logfile", "", "The log file, default = stdout")
 	doorbellDir := flag.String("belldir", "", "Directory that contains upstairs.wav, gate.wav etc. Wav needs to be named like")
-	httpPort := flag.Int("httpport", -1, "Port to listen HTTP requests on")
+	httpPort := flag.Int("httpport", -1, "Port to listen for HTTP requests on")
+	tcpPort := flag.Int("tcpport", -1, "Port to listen for TCP requests on")
 
 	flag.Parse()
 
@@ -160,6 +161,11 @@ func main() {
 	if *httpPort > 0 && *httpPort <= 65535 {
 		apiServer := NewApiServer(appEventBus, *httpPort)
 		go apiServer.Run()
+	}
+
+	if *tcpPort > 0 && *tcpPort <= 65535 {
+		tcpServer := NewTcpServer(appEventBus, *tcpPort)
+		go tcpServer.Run()
 	}
 
 	log.Println("Ready.")

--- a/software/earl/tcp-api.go
+++ b/software/earl/tcp-api.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sort"
+	"sync"
+)
+
+const (
+	CONN_HOST = "127.0.0.1"
+	CONN_TYPE = "tcp"
+)
+
+type TcpServer struct {
+	bus *ApplicationBus
+
+	// Remember the last event for each type. Already JSON prepared
+	eventChannel   AppEventChannel
+	lastEvents     map[AppEventType]*JsonAppEvent
+	lastEventsLock sync.Mutex
+	port           int
+}
+
+func NewTcpServer(bus *ApplicationBus, port int) *TcpServer {
+	newObject := &TcpServer{
+		bus:          bus,
+		eventChannel: make(AppEventChannel),
+		lastEvents:   make(map[AppEventType]*JsonAppEvent),
+		port:         port,
+	}
+	bus.Subscribe(newObject.eventChannel)
+	go newObject.collectLastEvents()
+	return newObject
+}
+
+func (a *TcpServer) collectLastEvents() {
+	for {
+		ev := <-a.eventChannel
+		// Remember the last event of each type.
+		a.lastEventsLock.Lock()
+		jsonified := JsonEventFromAppEvent(ev)
+		jsonified.IsHistoricEvent = true
+		a.lastEvents[ev.Ev] = jsonified
+		a.lastEventsLock.Unlock()
+	}
+}
+
+func (a *TcpServer) getHistory() []*JsonAppEvent {
+	result := EventList{}
+	a.lastEventsLock.Lock()
+	for _, ev := range a.lastEvents {
+		result = append(result, ev)
+	}
+	a.lastEventsLock.Unlock()
+	sort.Sort(result) // Show old events first
+	return result
+}
+
+func (a *TcpServer) ListenAndServe() {
+	listener, err := net.Listen(CONN_TYPE, fmt.Sprintf("%s:%d", CONN_HOST, a.port))
+	if err != nil {
+		fmt.Println("TcpServer error listening: ", err.Error())
+		return
+	}
+
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Println("TcpServer error accepting: ", err.Error())
+			os.Exit(1)
+		}
+		go a.handleTcpConnection(conn)
+	}
+}
+
+func (a *TcpServer) Run() {
+	a.ListenAndServe()
+}
+
+func (event *JsonAppEvent) writeJSONEventToTCP(conn net.Conn) bool {
+	json, err := json.Marshal(event)
+	if err != nil {
+		// Funny event, let's just ignore.
+		return true
+	}
+	_, err = conn.Write(json)
+	if err != nil {
+		return false
+	}
+	conn.Write([]byte("\n"))
+	return true
+}
+
+func (a *TcpServer) handleTcpConnection(conn net.Conn) {
+	defer conn.Close()
+
+	// Write out the historical events
+	for _, event := range a.getHistory() {
+		if !event.writeJSONEventToTCP(conn) {
+			break
+		}
+	}
+
+	// Subscribe and write out new events as published
+	appEvents := make(AppEventChannel, 3)
+	a.bus.Subscribe(appEvents)
+	for {
+		event := <-appEvents
+		if !JsonEventFromAppEvent(event).writeJSONEventToTCP(conn) {
+			break
+		}
+	}
+	a.bus.Unsubscribe(appEvents)
+}


### PR DESCRIPTION
Very similar to the HTTP server interface at the moment. Definitely some
future refactoring to these.

Moved the Event list code into its own module to share between the two.

tcp server is exposed w/ -tcpport= when running earl
