### PR TITLE
Add optional -version flag

### DIFF
--- a/software/earl/Makefile
+++ b/software/earl/Makefile
@@ -5,7 +5,7 @@
 all : earl test
 
 earl: *.go
-	go build
+	go build -ldflags "-X main.VERSION '`git log --date=short --pretty=format:'[%h] @ %cd' -n 1`'"
 
 test:
 	go test

--- a/software/earl/init.d/earl
+++ b/software/earl/init.d/earl
@@ -38,6 +38,8 @@ case $1 in
 			-- -logfile=$LOGFILE \
                         -belldir=/home/pi/doorbell-sounds \
 		        -httpport=1212 \
+                -users=/var/access/users.csv \
+                -tcpport=1213 \
 		        $SERIAL_INTERFACES
 		status=$?
 		log_end_msg $status

--- a/software/earl/main.go
+++ b/software/earl/main.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+// Inserted later w/ a linker flag.
+// Check the Makefile for details.
 var VERSION string
 
 // Each access point has their own name. The terminals can identify
@@ -51,7 +53,7 @@ type Backends struct {
 }
 
 func printVersionInfo() {
-	fmt.Println(fmt.Sprintf("Version: %s", VERSION))
+	fmt.Printf("Version: %s", VERSION)
 }
 
 func printUserList(auth *FileBasedAuthenticator) {

--- a/software/earl/main.go
+++ b/software/earl/main.go
@@ -10,8 +10,11 @@ import (
 	"time"
 )
 
+var VERSION string
+
 // Each access point has their own name. The terminals can identify
 // by that name.
+
 type Target string // TODO: find better name for this type
 const (
 	TargetDownstairs = Target("gate")
@@ -45,6 +48,10 @@ func parseArg(arg string) (devicepath string, baudrate int) {
 type Backends struct {
 	authenticator Authenticator
 	appEventBus   *ApplicationBus
+}
+
+func printVersionInfo() {
+	fmt.Println(fmt.Sprintf("Version: %s", VERSION))
 }
 
 func printUserList(auth *FileBasedAuthenticator) {
@@ -143,14 +150,20 @@ func handleSerialDevice(devicepath string, baud int, backends *Backends) {
 }
 
 func main() {
-	userFileName := flag.String("users", "/var/access/users.csv", "User Authentication file.")
+	userFileName := flag.String("users", "", "User Authentication file.")
 	logFileName := flag.String("logfile", "", "The log file, default = stdout")
 	doorbellDir := flag.String("belldir", "", "Directory that contains upstairs.wav, gate.wav etc. Wav needs to be named like")
 	httpPort := flag.Int("httpport", -1, "Port to listen HTTP requests on")
 	tcpPort := flag.Int("tcpport", -1, "Port to listen for TCP requests on")
 	list_users := flag.Bool("list-users", false, "List users and exit")
+	show_version := flag.Bool("version", false, "Print version info")
 
 	flag.Parse()
+
+	if *show_version {
+		printVersionInfo()
+		return
+	}
 
 	if *logFileName != "" {
 		logfile, err := os.OpenFile(*logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)

--- a/software/earl/main.go
+++ b/software/earl/main.go
@@ -163,6 +163,15 @@ func main() {
 
 	log.Println("Starting...")
 
+	if len(flag.Args()) < 1 && !*list_users {
+		fmt.Fprintf(os.Stderr,
+			"Expected list of serial ports."+
+				"usage: %s [options] <serial-device>[:baudrate] [<serial-device>[:baudrate]...]\nOptions\n",
+			os.Args[0])
+		flag.PrintDefaults()
+		return
+	}
+
 	appEventBus := NewApplicationBus()
 	authenticator := NewFileBasedAuthenticator(*userFileName,
 		appEventBus)
@@ -178,15 +187,6 @@ func main() {
 	// If we just requested to list users, do this and exit.
 	if *list_users {
 		printUserList(authenticator)
-		return
-	}
-
-	if len(flag.Args()) < 1 {
-		fmt.Fprintf(os.Stderr,
-			"Expected list of serial ports."+
-				"usage: %s [options] <serial-device>[:baudrate] [<serial-device>[:baudrate]...]\nOptions\n",
-			os.Args[0])
-		flag.PrintDefaults()
 		return
 	}
 


### PR DESCRIPTION
Prints out the current version

`Makefile` uses `-ldflags` to set the `VERSION` symbol to a nice human readable string with the `HEAD` git SHA and the current date. 

Removes the default value for the `-users` argument, instead move this into the `init.d` file as an explicit argument.
