### PR TITLE
Allow users in earlier and later

### DIFF
--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -176,7 +176,7 @@ func (user *User) AccessHours() (from int, to int) {
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
 	case LevelUser:
-		return 11, 23 // 11:00 .. 22:59
+		return 10, 23 // 10:00 .. 22:59
 	}
 	// TODO: for time-restricted users such as users for classes,
 	// we can have custom hours here that don't depend on the UserLevel

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -176,7 +176,7 @@ func (user *User) AccessHours() (from int, to int) {
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
 	case LevelUser:
-		return 11, 22 // 11:00 .. 21:59
+		return 11, 23 // 11:00 .. 22:59
 	}
 	// TODO: for time-restricted users such as users for classes,
 	// we can have custom hours here that don't depend on the UserLevel


### PR DESCRIPTION
An attempt at hewing closer to the Noisebridge policy of being "as open as possible".