### PR TITLE
Brings in the changes made since March

### DIFF
--- a/software/earl/authenticator.go
+++ b/software/earl/authenticator.go
@@ -504,7 +504,7 @@ func (a *FileBasedAuthenticator) userHasAccess(user *User, target Target) (AuthR
 	case LevelMember:
 		return AuthOk, "" // Members always have access.
 
-	case LevelPhilanthropist: // Philanthropists also have all-hour access
+	case LevelPhilanthropist, LevelTrustedPhilanthropist: // Philanthropists also have all-hour access
 		return AuthOk, ""
 
 	case LevelFulltimeUser:

--- a/software/earl/authenticator_test.go
+++ b/software/earl/authenticator_test.go
@@ -255,8 +255,8 @@ func TestTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_22h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour + 30 * time.Minute) // 23:00
 
 	// After 30 days, non-contact users expire.
 	// So fast forward 31 days, 16:00 in the afternoon.
@@ -385,8 +385,8 @@ func TestHolidayTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_22h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour + 30 * time.Minute) // 23:00
 
 	// We 'register' the users a day before
 	mockClock.now = someMidnight.Add(-12 * time.Hour)

--- a/software/earl/authenticator_test.go
+++ b/software/earl/authenticator_test.go
@@ -255,8 +255,8 @@ func TestTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
-	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
+	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
 
 	// After 30 days, non-contact users expire.
 	// So fast forward 31 days, 16:00 in the afternoon.
@@ -341,7 +341,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "member_nocontact", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs, AuthOk, "")
 
-	mockClock.now = closingTime_23h // should behave similar to earlyMorning
+	mockClock.now = closingTime_22h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -351,7 +351,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23_5h // members, philanthropists, and fulltimeusers left
+	mockClock.now = lateStayUsers_23h // members, philanthropists, and fulltimeusers left
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -385,8 +385,8 @@ func TestHolidayTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
-	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
+	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
 
 	// We 'register' the users a day before
 	mockClock.now = someMidnight.Add(-12 * time.Hour)
@@ -411,11 +411,11 @@ func TestHolidayTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "holiday")
 
-	mockClock.now = closingTime_23h // should behave similar to earlyMorning
+	mockClock.now = closingTime_22h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23_5h
+	mockClock.now = lateStayUsers_23h
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 }

--- a/software/earl/authenticator_test.go
+++ b/software/earl/authenticator_test.go
@@ -255,8 +255,8 @@ func TestTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
 
 	// After 30 days, non-contact users expire.
 	// So fast forward 31 days, 16:00 in the afternoon.
@@ -341,7 +341,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "member_nocontact", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs, AuthOk, "")
 
-	mockClock.now = closingTime_22h // should behave similar to earlyMorning
+	mockClock.now = closingTime_23h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -351,7 +351,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23h // members, philanthropists, and fulltimeusers left
+	mockClock.now = lateStayUsers_23_5h // members, philanthropists, and fulltimeusers left
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -385,8 +385,8 @@ func TestHolidayTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
 
 	// We 'register' the users a day before
 	mockClock.now = someMidnight.Add(-12 * time.Hour)
@@ -411,11 +411,11 @@ func TestHolidayTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "holiday")
 
-	mockClock.now = closingTime_22h // should behave similar to earlyMorning
+	mockClock.now = closingTime_23h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23h
+	mockClock.now = lateStayUsers_23_5h
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 }

--- a/software/earl/uicontrolhandler.go
+++ b/software/earl/uicontrolhandler.go
@@ -2,8 +2,8 @@
 // A TerminalEventHandler, that interacts with users in the space.
 //
 // Its primary goal is not to open doors and such, but to provide an
-// user-interface to verify RFID cards and convenient way for members to
-// add new users.
+// user-interface to verify RFID cards and convenient way for members
+// and trusted philanthropists to add new users.
 //
 // It is a regular terminal (same serial protocol), but has a LCD attached as
 // output and a Keypad and RFID reader as input.
@@ -24,7 +24,7 @@ const (
 	StateIdle               = iota // When there is nothing to do; idle screen.
 	StateDisplayInfoMessage        // Interrupt idle screen and show info message
 	StateWaitMenuChoice            // Member/Philanthropist showed RFID; awaiting instruction
-	StateAddAwaitNewRFID           // Member adds new user: wait for new user RFID
+	StateAddAwaitNewRFID           // Member/TrustedPhilanthropist adds new user: wait for new user RFID
 	StateUpdateAwaitRFID           // Member/Philanthropist updates user: wait for new user RFID
 	StateDoorbellRequest           // Someone just rang
 	StateDooropenRequest           // Someone at control just requested to open a door regardless of doorbell
@@ -178,6 +178,10 @@ func (u *UIControlHandler) HandleRFID(rfid string) {
 			u.t.WriteLCD(1, "Ask a member to register")
 		} else {
 			switch user.UserLevel {
+			case LevelTrustedPhilanthropist:
+				u.authUserCode = rfid
+				u.presentTrustedPhilanthropistActions(user)
+
 			case LevelMember:
 				u.authUserCode = rfid
 				u.presentMemberActions(user)
@@ -327,6 +331,13 @@ func (u *UIControlHandler) displayIdleScreen() {
 }
 
 func (u *UIControlHandler) presentMemberActions(member *User) {
+	u.t.WriteLCD(0, fmt.Sprintf("Howdy %s", member.Name))
+	u.t.WriteLCD(1, "[*]ESC [1]Add [2]Renew")
+	// @TODO: allow members to make philanthropists trusted philanthropists
+	u.setStateWithTimeout(StateWaitMenuChoice, 5*time.Second)
+}
+
+func (u *UIControlHandler) presentTrustedPhilanthropistActions(member *User) {
 	u.t.WriteLCD(0, fmt.Sprintf("Howdy %s", member.Name))
 	u.t.WriteLCD(1, "[*]ESC [1]Add [2]Renew")
 

--- a/software/earl/uicontrolhandler.go
+++ b/software/earl/uicontrolhandler.go
@@ -31,7 +31,7 @@ const (
 
 const (
 	// Display doorbell for this amount of time
-	showDoorbellDuration = 75 * time.Second
+	showDoorbellDuration = 120 * time.Second
 
 	// For annoying people...
 	offerSilenceWhenRepeatedRingsUnder = 2 * time.Second

--- a/software/earl/uicontrolhandler.go
+++ b/software/earl/uicontrolhandler.go
@@ -27,6 +27,7 @@ const (
 	StateAddAwaitNewRFID           // Member adds new user: wait for new user RFID
 	StateUpdateAwaitRFID           // Member/Philanthropist updates user: wait for new user RFID
 	StateDoorbellRequest           // Someone just rang
+	StateDooropenRequest           // Someone at control just requested to open a door regardless of doorbell
 )
 
 const (
@@ -60,6 +61,7 @@ type UIControlHandler struct {
 	// We allow rate-limiting of the doorbell.
 	lastDoorbellRequest time.Time // To know when to offer hush.
 	doorbellTarget      Target
+	dooropenTarget      Target
 	endDoorbellHush     time.Time // Incremented
 
 	// Stuff collected from events we see, mostly to
@@ -106,10 +108,31 @@ func (u *UIControlHandler) CurrentAuthLevel() Level {
 	return user.UserLevel
 }
 
+func keyToTarget(key byte) (Target, bool) {
+	switch key {
+	case '4':
+		return TargetDownstairs, false
+	case '5':
+		return TargetUpstairs, false
+	case '6':
+		return TargetElevator, false
+	}
+	return TargetControlUI, true
+}
+
 func (u *UIControlHandler) HandleKeypress(key byte) {
 	if key == '*' { // The '*' key is always 'Esc'-equivalent
 		u.backToIdle()
 		return
+	}
+
+	// If user presses 4,5,6 they are requesting to open a specific door without regard for doorbells or lack thereof
+	target, err := keyToTarget(key)
+	if !err {
+		u.t.WriteLCD(0, fmt.Sprintf("RFID: open at %s", target))
+		u.t.WriteLCD(1, "[*] Cancel")
+		u.dooropenTarget = target
+		u.setStateWithTimeout(StateDooropenRequest, 30*time.Second)
 	}
 
 	switch u.state {
@@ -213,7 +236,14 @@ func (u *UIControlHandler) HandleRFID(rfid string) {
 		// we assume they are allowed to open the door.
 		// TODO: revisit and allow memmbers once their density increases ?
 		if u.auth.FindUser(rfid) != nil {
-			u.openDoorAndShow(u.doorbellTarget, "via RFID on control")
+			if u.doorbellTarget == TargetDownstairs {
+				u.openDoorAndShow(u.doorbellTarget, "via RFID on control")
+				u.backToIdle()
+			}
+		}
+	case StateDooropenRequest:
+		if u.auth.FindUser(rfid) != nil {
+			u.openDoorAndShow(u.dooropenTarget, "via RFID on control")
 			u.backToIdle()
 		}
 	}
@@ -365,9 +395,11 @@ func (u *UIControlHandler) startDoorOpenUI(target Target, message string) {
 	}
 	u.t.WriteLCD(0, fmt.Sprintf("%*s", fmt_len, to_display))
 
+	if target != TargetDownstairs {
+		u.t.WriteLCD(1, "[*] ESC | [9] Silence")
 	// The hush option always works, but we only show it when there is
 	// some repeated annoyance going on to keep UI simple in the simple case
-	if now.Sub(u.lastDoorbellRequest) < offerSilenceWhenRepeatedRingsUnder {
+	} else if now.Sub(u.lastDoorbellRequest) < offerSilenceWhenRepeatedRingsUnder {
 		u.t.WriteLCD(1, "RFID:Open | [9] Silence!")
 	} else {
 		u.t.WriteLCD(1, "RFID:Open | [*] ESC")

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -176,7 +176,7 @@ func (user *User) AccessHours() (from int, to int) {
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
 	case LevelUser:
-		return 11, 23 // 11:00 .. 22:59
+		return 10, 23 // 10:00 .. 22:59
 	}
 	// TODO: for time-restricted users such as users for classes,
 	// we can have custom hours here that don't depend on the UserLevel

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -40,6 +40,8 @@ const (
 
 	// A user with 24/7 access to the space, but who cannot add users.
 	LevelPhilanthropist = Level("philanthropist")
+	// A philanthropist that has been granted the ability to add tokens by a member.
+	LevelTrustedPhilanthropist = Level("trustedphilanthropist")
 )
 
 const (
@@ -108,7 +110,7 @@ func NewUserFromCSV(reader *csv.Reader) (user *User, done bool) {
 
 func isValidLevel(input string) bool {
 	switch input {
-	case "member", "user", "fulltimeuser", "hiatus", "philanthropist":
+	case "member", "user", "fulltimeuser", "hiatus", "philanthropist", "trustedphilanthropist":
 		return true
 	default:
 		return false
@@ -171,7 +173,7 @@ func (user *User) AccessHours() (from int, to int) {
 	switch user.UserLevel {
 	case LevelMember:
 		return 0, 24 // all access
-	case LevelPhilanthropist:
+	case LevelPhilanthropist, LevelTrustedPhilanthropist:
 		return 0, 24 // all access
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
@@ -198,7 +200,7 @@ func (user *User) SetAuthCode(code string) bool {
 func CanLevelModify(l Level) bool {
 	// Philanthropist are allowed to renew user tokens.
 	switch l {
-	case LevelMember, LevelPhilanthropist:
+	case LevelMember, LevelPhilanthropist, LevelTrustedPhilanthropist:
 		return true
 	}
 	return false
@@ -206,7 +208,7 @@ func CanLevelModify(l Level) bool {
 
 func CanLevelAddDelete(l Level) bool {
 	switch l {
-	case LevelMember:
+	case LevelMember, LevelTrustedPhilanthropist:
 		return true
 	}
 	return false

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -176,7 +176,7 @@ func (user *User) AccessHours() (from int, to int) {
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
 	case LevelUser:
-		return 11, 22 // 11:00 .. 21:59
+		return 11, 23 // 11:00 .. 22:59
 	}
 	// TODO: for time-restricted users such as users for classes,
 	// we can have custom hours here that don't depend on the UserLevel


### PR DESCRIPTION
All of the changes except the most recent ones should be able to be merged without any issues. IINM @rizend's most recent version implements the most recent consensus item on the subject of RFID changes, but doesn't yet include a way for members to upgrade philanthropists via the RFID terminal, so they must be added manually like philanthropists and members must be added.

https://www.noisebridge.net/wiki/Consensus_Items_History

---

**Let Philanthropists Grant 30-day RFID Access**

Consensus Item Date: 2018-10-23
Proposed By: R
Consensus Item Text: 30-day daytime access to the space through the RFID access control system can be activated by Philanthropists (but the right for a philanthropist to give daytime access is granted by a member).

---

**Extend RFID Hours to 10:00-23:00**

Relevant meeting notes:

[First discussed](https://www.noisebridge.net/wiki/Meeting_notes_2018_03_06#As_open_as_possible_--_mod_hours_from_11:00-22:00_to_10:00-23:00)

[R mentions they will be reploying](https://www.noisebridge.net/wiki/Meeting_notes_2018_03_20)