### PR TITLE
Adds control panel feature upgrades

### DIFF
--- a/software/earl/authenticator_test.go
+++ b/software/earl/authenticator_test.go
@@ -262,8 +262,8 @@ func TestTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_22h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour + 30 * time.Minute) // 23:00
 
 	// After 30 days, non-contact users expire.
 	// So fast forward 31 days, 16:00 in the afternoon.
@@ -392,8 +392,8 @@ func TestHolidayTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_22h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour + 30 * time.Minute) // 23:00
 
 	// We 'register' the users a day before
 	mockClock.now = someMidnight.Add(-12 * time.Hour)

--- a/software/earl/authenticator_test.go
+++ b/software/earl/authenticator_test.go
@@ -262,8 +262,8 @@ func TestTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
 
 	// After 30 days, non-contact users expire.
 	// So fast forward 31 days, 16:00 in the afternoon.
@@ -348,7 +348,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "member_nocontact", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs, AuthOk, "")
 
-	mockClock.now = closingTime_22h // should behave similar to earlyMorning
+	mockClock.now = closingTime_23h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -358,7 +358,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23h // members, philanthropists, and fulltimeusers left
+	mockClock.now = lateStayUsers_23_5h // members, philanthropists, and fulltimeusers left
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -392,8 +392,8 @@ func TestHolidayTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
-	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
+	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
+	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
 
 	// We 'register' the users a day before
 	mockClock.now = someMidnight.Add(-12 * time.Hour)
@@ -418,11 +418,11 @@ func TestHolidayTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "holiday")
 
-	mockClock.now = closingTime_22h // should behave similar to earlyMorning
+	mockClock.now = closingTime_23h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23h
+	mockClock.now = lateStayUsers_23_5h
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 }

--- a/software/earl/authenticator_test.go
+++ b/software/earl/authenticator_test.go
@@ -262,8 +262,8 @@ func TestTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
-	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
+	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
 
 	// After 30 days, non-contact users expire.
 	// So fast forward 31 days, 16:00 in the afternoon.
@@ -348,7 +348,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "member_nocontact", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs, AuthOk, "")
 
-	mockClock.now = closingTime_23h // should behave similar to earlyMorning
+	mockClock.now = closingTime_22h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -358,7 +358,7 @@ func TestTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user_nocontact", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23_5h // members, philanthropists, and fulltimeusers left
+	mockClock.now = lateStayUsers_23h // members, philanthropists, and fulltimeusers left
 	ExpectAuthResult(t, auth, "member123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "philanthropist123", TargetUpstairs, AuthOk, "")
 	ExpectAuthResult(t, auth, "fulltimeuser123", TargetUpstairs, AuthOk, "")
@@ -392,8 +392,8 @@ func TestHolidayTimeLimits(t *testing.T) {
 	nightTime_3h := someMidnight.Add(3 * time.Hour)           // 03:00
 	earlyMorning_7h := someMidnight.Add(7 * time.Hour)        // 09:00
 	hackerDaytime_13h := someMidnight.Add(13 * time.Hour)     // 16:00
-	closingTime_23h := someMidnight.Add(23 * time.Hour)       // 22:00
-	lateStayUsers_23_5h := someMidnight.Add(23 * time.Hour + time.Minute * 30)     // 23:00
+	closingTime_22h := someMidnight.Add(22 * time.Hour)       // 22:00
+	lateStayUsers_23h := someMidnight.Add(23 * time.Hour)     // 23:00
 
 	// We 'register' the users a day before
 	mockClock.now = someMidnight.Add(-12 * time.Hour)
@@ -418,11 +418,11 @@ func TestHolidayTimeLimits(t *testing.T) {
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "holiday")
 
-	mockClock.now = closingTime_23h // should behave similar to earlyMorning
+	mockClock.now = closingTime_22h // should behave similar to earlyMorning
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 
-	mockClock.now = lateStayUsers_23_5h
+	mockClock.now = lateStayUsers_23h
 	ExpectAuthResult(t, auth, "user123", TargetUpstairs,
 		AuthOkButOutsideTime, "outside")
 }

--- a/software/earl/uicontrolhandler.go
+++ b/software/earl/uicontrolhandler.go
@@ -27,6 +27,7 @@ const (
 	StateAddAwaitNewRFID           // Member adds new user: wait for new user RFID
 	StateUpdateAwaitRFID           // Member/Philanthropist updates user: wait for new user RFID
 	StateDoorbellRequest           // Someone just rang
+	StateDooropenRequest           // Someone at control just requested to open a door regardless of doorbell
 )
 
 const (
@@ -60,6 +61,7 @@ type UIControlHandler struct {
 	// We allow rate-limiting of the doorbell.
 	lastDoorbellRequest time.Time // To know when to offer hush.
 	doorbellTarget      Target
+	dooropenTarget      Target
 	endDoorbellHush     time.Time // Incremented
 
 	// Stuff collected from events we see, mostly to
@@ -106,10 +108,31 @@ func (u *UIControlHandler) CurrentAuthLevel() Level {
 	return user.UserLevel
 }
 
+func keyToTarget(key byte) (Target, bool) {
+	switch key {
+	case '4':
+		return TargetDownstairs, false
+	case '5':
+		return TargetUpstairs, false
+	case '6':
+		return TargetElevator, false
+	}
+	return TargetControlUI, true
+}
+
 func (u *UIControlHandler) HandleKeypress(key byte) {
 	if key == '*' { // The '*' key is always 'Esc'-equivalent
 		u.backToIdle()
 		return
+	}
+
+	// If user presses 4,5,6 they are requesting to open a specific door without regard for doorbells or lack thereof
+	target, err := keyToTarget(key)
+	if !err {
+		u.t.WriteLCD(0, fmt.Sprintf("RFID: open at %s", target))
+		u.t.WriteLCD(1, "[*] Cancel")
+		u.dooropenTarget = target
+		u.setStateWithTimeout(StateDooropenRequest, 30*time.Second)
 	}
 
 	switch u.state {
@@ -213,7 +236,14 @@ func (u *UIControlHandler) HandleRFID(rfid string) {
 		// we assume they are allowed to open the door.
 		// TODO: revisit and allow memmbers once their density increases ?
 		if u.auth.FindUser(rfid) != nil {
-			u.openDoorAndShow(u.doorbellTarget, "via RFID on control")
+			if u.doorbellTarget == TargetDownstairs {
+				u.openDoorAndShow(u.doorbellTarget, "via RFID on control")
+				u.backToIdle()
+			}
+		}
+	case StateDooropenRequest:
+		if u.auth.FindUser(rfid) != nil {
+			u.openDoorAndShow(u.dooropenTarget, "via RFID on control")
 			u.backToIdle()
 		}
 	}
@@ -363,9 +393,11 @@ func (u *UIControlHandler) startDoorOpenUI(target Target, message string) {
 	}
 	u.t.WriteLCD(0, fmt.Sprintf("%*s", fmt_len, to_display))
 
+	if target != TargetDownstairs {
+		u.t.WriteLCD(1, "[*] ESC | [9] Silence")
 	// The hush option always works, but we only show it when there is
 	// some repeated annoyance going on to keep UI simple in the simple case
-	if now.Sub(u.lastDoorbellRequest) < offerSilenceWhenRepeatedRingsUnder {
+	} else if now.Sub(u.lastDoorbellRequest) < offerSilenceWhenRepeatedRingsUnder {
 		u.t.WriteLCD(1, "RFID:Open | [9] Silence!")
 	} else {
 		u.t.WriteLCD(1, "RFID:Open | [*] ESC")

--- a/software/earl/uicontrolhandler.go
+++ b/software/earl/uicontrolhandler.go
@@ -31,7 +31,7 @@ const (
 
 const (
 	// Display doorbell for this amount of time
-	showDoorbellDuration = 75 * time.Second
+	showDoorbellDuration = 120 * time.Second
 
 	// For annoying people...
 	offerSilenceWhenRepeatedRingsUnder = 2 * time.Second

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -176,7 +176,7 @@ func (user *User) AccessHours() (from int, to int) {
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
 	case LevelUser:
-		return 11, 23 // 11:00 .. 22:59
+		return 10, 23 // 10:00 .. 22:59
 	}
 	// TODO: for time-restricted users such as users for classes,
 	// we can have custom hours here that don't depend on the UserLevel

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -176,7 +176,7 @@ func (user *User) AccessHours() (from int, to int) {
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
 	case LevelUser:
-		return 11, 22 // 11:00 .. 21:59
+		return 11, 23 // 11:00 .. 22:59
 	}
 	// TODO: for time-restricted users such as users for classes,
 	// we can have custom hours here that don't depend on the UserLevel


### PR DESCRIPTION
This PR adds in @rizend's new features for the Earl control panel. It is an extension of prior commits, so you should compare to the branch from the [Extends open hours PR](https://github.com/noisebridge/rfid-access-control/pull/29), NOT to the current NB master.

_**NOTE: This should be merged only after [Extends open hours](https://github.com/noisebridge/rfid-access-control/pull/29)**_

---

New Features:

- Doorbell can be opened within 120 seconds of being rung, instead of just 75 seconds
- Keypad buttons 4-6 now can be used to open various door locks without there being a bell (good for when people haven't yet re-rung the downstairs bell b/c they don't know about the time limit)