### PR TITLE
Implement new Philanthropist 30 day grant

### DIFF
--- a/software/earl/authenticator.go
+++ b/software/earl/authenticator.go
@@ -504,7 +504,7 @@ func (a *FileBasedAuthenticator) userHasAccess(user *User, target Target) (AuthR
 	case LevelMember:
 		return AuthOk, "" // Members always have access.
 
-	case LevelPhilanthropist: // Philanthropists also have all-hour access
+	case LevelPhilanthropist, LevelTrustedPhilanthropist: // Philanthropists also have all-hour access
 		return AuthOk, ""
 
 	case LevelFulltimeUser:

--- a/software/earl/authenticator_test.go
+++ b/software/earl/authenticator_test.go
@@ -132,22 +132,15 @@ func TestAddUser(t *testing.T) {
 	// Let's add an Philanthropist as well.
 	u.Name = "Joe Philanthropist"
 	u.UserLevel = LevelPhilanthropist
-	u.ValidTo = time.Now().Add(1 * time.Hour)
-	u.ContactInfo = "phil@foo"
 	u.SetAuthCode("phil123")
 	auth.AddNewUser("root123", u)
 
 	// Permission testing:
-	u.Name = "Attempt Jon Doe adding"
-	u.SetAuthCode("fromdoe")
 	ExpectFalse(t, eatmsg(auth.AddNewUser("doe123", u)),
 		"Attempt to add user by non-member")
 
-	// A Philanthropist however, can add a new user.
-	u.Name = "Philanthropist adding"
-	u.SetAuthCode("fromphil")
-	ExpectTrue(t, eatmsg(auth.AddNewUser("phil123", u)),
-		"Philanthropist adding new user")
+	ExpectFalse(t, eatmsg(auth.AddNewUser("phil123", u)),
+		"Attempt to add user by non-member")
 
 	// Ok, now let's see if an new authenticator can make sense of the
 	// file we appended to.

--- a/software/earl/uicontrolhandler.go
+++ b/software/earl/uicontrolhandler.go
@@ -334,8 +334,10 @@ func (u *UIControlHandler) presentMemberActions(member *User) {
 }
 
 func (u *UIControlHandler) presentPhilanthropistActions(member *User) {
-	// Meeting 2018-10-23: Philanthropists can do same as members.
-	u.presentMemberActions(member)
+	u.t.WriteLCD(0, fmt.Sprintf("Howdy %s", member.Name))
+	u.t.WriteLCD(1, "[*] ESC [2] Renew token")
+
+	u.setStateWithTimeout(StateWaitMenuChoice, 5*time.Second)
 }
 
 func (u *UIControlHandler) displayUserInfo(user *User) {

--- a/software/earl/uicontrolhandler.go
+++ b/software/earl/uicontrolhandler.go
@@ -2,8 +2,8 @@
 // A TerminalEventHandler, that interacts with users in the space.
 //
 // Its primary goal is not to open doors and such, but to provide an
-// user-interface to verify RFID cards and convenient way for members to
-// add new users.
+// user-interface to verify RFID cards and convenient way for members
+// and trusted philanthropists to add new users.
 //
 // It is a regular terminal (same serial protocol), but has a LCD attached as
 // output and a Keypad and RFID reader as input.
@@ -24,7 +24,7 @@ const (
 	StateIdle               = iota // When there is nothing to do; idle screen.
 	StateDisplayInfoMessage        // Interrupt idle screen and show info message
 	StateWaitMenuChoice            // Member/Philanthropist showed RFID; awaiting instruction
-	StateAddAwaitNewRFID           // Member adds new user: wait for new user RFID
+	StateAddAwaitNewRFID           // Member/TrustedPhilanthropist adds new user: wait for new user RFID
 	StateUpdateAwaitRFID           // Member/Philanthropist updates user: wait for new user RFID
 	StateDoorbellRequest           // Someone just rang
 	StateDooropenRequest           // Someone at control just requested to open a door regardless of doorbell
@@ -178,6 +178,10 @@ func (u *UIControlHandler) HandleRFID(rfid string) {
 			u.t.WriteLCD(1, "Ask a member to register")
 		} else {
 			switch user.UserLevel {
+			case LevelTrustedPhilanthropist:
+				u.authUserCode = rfid
+				u.presentTrustedPhilanthropistActions(user)
+
 			case LevelMember:
 				u.authUserCode = rfid
 				u.presentMemberActions(user)
@@ -327,6 +331,13 @@ func (u *UIControlHandler) displayIdleScreen() {
 }
 
 func (u *UIControlHandler) presentMemberActions(member *User) {
+	u.t.WriteLCD(0, fmt.Sprintf("Howdy %s", member.Name))
+	u.t.WriteLCD(1, "[*]ESC [1]Add [2]Renew")
+	// @TODO: allow members to make philanthropists trusted philanthropists
+	u.setStateWithTimeout(StateWaitMenuChoice, 5*time.Second)
+}
+
+func (u *UIControlHandler) presentTrustedPhilanthropistActions(member *User) {
 	u.t.WriteLCD(0, fmt.Sprintf("Howdy %s", member.Name))
 	u.t.WriteLCD(1, "[*]ESC [1]Add [2]Renew")
 

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -206,8 +206,7 @@ func CanLevelModify(l Level) bool {
 
 func CanLevelAddDelete(l Level) bool {
 	switch l {
-	// Meeting 2018-10-23: Philanthropists also can add new
-	case LevelMember, LevelPhilanthropist:
+	case LevelMember:
 		return true
 	}
 	return false

--- a/software/earl/user.go
+++ b/software/earl/user.go
@@ -40,6 +40,8 @@ const (
 
 	// A user with 24/7 access to the space, but who cannot add users.
 	LevelPhilanthropist = Level("philanthropist")
+	// A philanthropist that has been granted the ability to add tokens by a member.
+	LevelTrustedPhilanthropist = Level("trustedphilanthropist")
 )
 
 const (
@@ -108,7 +110,7 @@ func NewUserFromCSV(reader *csv.Reader) (user *User, done bool) {
 
 func isValidLevel(input string) bool {
 	switch input {
-	case "member", "user", "fulltimeuser", "hiatus", "philanthropist":
+	case "member", "user", "fulltimeuser", "hiatus", "philanthropist", "trustedphilanthropist":
 		return true
 	default:
 		return false
@@ -171,7 +173,7 @@ func (user *User) AccessHours() (from int, to int) {
 	switch user.UserLevel {
 	case LevelMember:
 		return 0, 24 // all access
-	case LevelPhilanthropist:
+	case LevelPhilanthropist, LevelTrustedPhilanthropist:
 		return 0, 24 // all access
 	case LevelFulltimeUser:
 		return 7, 24 // 7:00 .. 23:59
@@ -198,7 +200,7 @@ func (user *User) SetAuthCode(code string) bool {
 func CanLevelModify(l Level) bool {
 	// Philanthropist are allowed to renew user tokens.
 	switch l {
-	case LevelMember, LevelPhilanthropist:
+	case LevelMember, LevelPhilanthropist, LevelTrustedPhilanthropist:
 		return true
 	}
 	return false
@@ -206,7 +208,7 @@ func CanLevelModify(l Level) bool {
 
 func CanLevelAddDelete(l Level) bool {
 	switch l {
-	case LevelMember:
+	case LevelMember, LevelTrustedPhilanthropist:
 		return true
 	}
 	return false


### PR DESCRIPTION
This pull request
  - Undos hzeller's the first implementation of Philanthropist 30 day access https://github.com/noisebridge/rfid-access-control/commit/1a08324942a469d1982debf4e6b00f20a37db3b9
  - and replaces it with rizend's implementation that allows for more fine-grained control who can https://github.com/noisebridge/rfid-access-control/pull/31/commits/17e4035dece9bac2d0c9d6d314db60772d9414ca