### PR TITLE
Fix http API metric observation

### DIFF
--- a/software/earl/http-api.go
+++ b/software/earl/http-api.go
@@ -133,7 +133,9 @@ func (event *JsonAppEvent) writeJSONEvent(out http.ResponseWriter, jsonp_callbac
 
 func (a *ApiServer) ServeHTTP(out http.ResponseWriter, req *http.Request) {
 	begin := time.Now()
-	defer httpRequestDurationSeconds.With(prometheus.Labels{"method": req.Method}).Observe(time.Since(begin).Seconds())
+	defer func() {
+		httpRequestDurationSeconds.With(prometheus.Labels{"method": req.Method}).Observe(time.Since(begin).Seconds())
+	}()
 
 	if req.Method != "GET" && req.Method != "POST" {
 		out.WriteHeader(http.StatusMethodNotAllowed)


### PR DESCRIPTION
Wrap defer in anonymous func to avoid evaluating time.Since() early.